### PR TITLE
Optimize memory usage

### DIFF
--- a/segypy.py
+++ b/segypy.py
@@ -447,10 +447,10 @@ def read_binary_value(f, index, ctype='l', endian='>', number=1):
     data = f.read(size * number)
     if ctype == 'ibm':
         # ASSUME IBM FLOAT DATA
-        value = np.empty(number, dtype=np.float32)
+        value = np.empty(number)
         for i in np.arange(number):
             index_ibm = i * 4
-            value[i] = np.float32(ibm2ieee2(data[index_ibm: index_ibm + 4]))
+            value[i] = ibm2ieee2(data[index_ibm: index_ibm + 4])
         # this returns an array as opposed to a tuple
     else:
         cformat = endian + ctype * number

--- a/segypy.py
+++ b/segypy.py
@@ -447,10 +447,10 @@ def read_binary_value(f, index, ctype='l', endian='>', number=1):
     data = f.read(size * number)
     if ctype == 'ibm':
         # ASSUME IBM FLOAT DATA
-        value = np.empty(number)
+        value = np.empty(number, dtype=np.float32)
         for i in np.arange(number):
             index_ibm = i * 4
-            value[i] = ibm2ieee2(data[index_ibm: index_ibm + 4])
+            value[i] = np.float32(ibm2ieee2(data[index_ibm: index_ibm + 4]))
         # this returns an array as opposed to a tuple
     else:
         cformat = endian + ctype * number

--- a/segypy.py
+++ b/segypy.py
@@ -31,7 +31,7 @@ import sys
 import struct
 import logging
 
-from numpy import (transpose, reshape, zeros, arange)
+from numpy import (transpose, reshape, zeros, arange, prod)
 
 from revisions import canonicalize_revision
 from header_definition import HEADER_DEF
@@ -232,9 +232,9 @@ def read_traces(f,
     values, _ = read_binary_value(f, index, ctype, endian, num_data)
 
     logger.debug("read_traces : - reshaping")
-    values = reshape(values,
-                     (reel_header['ntraces'],
-                      reel_header['ns'] + num_dummy_samples))
+    vshape = (reel_header['ntraces'], reel_header['ns'] + num_dummy_samples)
+    values = values[:prod(vshape)]
+    values = reshape(values, vshape)
     logger.debug("read_traces : - stripping header dummy data")
     values = values[:, num_dummy_samples:
                     (reel_header['ns'] + num_dummy_samples)]


### PR DESCRIPTION
A few changes to keep memory consumption down while reading in SEG-Y files.
- Avoid creating format strings unnecessarily.
- Read in the data into an array instead of a list.
- Keep the values as 32 bit instead of converting to 64 bit.