### PR TITLE
Issue #23, fixed failing test_ceil and test_floor in test_float

### DIFF
--- a/test/test_float.py
+++ b/test/test_float.py
@@ -213,17 +213,15 @@ class TestIBMFloat(unittest.TestCase):
         self.assertEqual(trunc(ibm), i)
 
     @given(integers_in_range(MIN_EXACT_INTEGER_IBM_FLOAT, MAX_EXACT_INTEGER_IBM_FLOAT - 1),
-           floats_in_range(0.0, 1.0))
+           floats_in_range(EPSILON_IBM_FLOAT, 1.0-EPSILON_IBM_FLOAT))
     def test_ceil(self, i, f):
-        assume(f != 1.0)
         ieee = i + f
         ibm = IBMFloat.from_float(ieee)
         self.assertEqual(math.ceil(ibm), i + 1)
 
     @given(integers_in_range(MIN_EXACT_INTEGER_IBM_FLOAT, MAX_EXACT_INTEGER_IBM_FLOAT - 1),
-           floats_in_range(0.0, 1.0))
+           floats_in_range(EPSILON_IBM_FLOAT, 1.0-EPSILON_IBM_FLOAT))
     def test_floor(self, i, f):
-        assume(f != 1.0)
         ieee = i + f
         ibm = IBMFloat.from_float(ieee)
         self.assertEqual(math.floor(ibm), i)


### PR DESCRIPTION
Change the way supplied floats are generated. Interval should not be (0.0,1,0).
It should be (eps,1.0-eps). Then the assumption f!=1.0 can be removed