### PR TITLE
Added tests for use of correct IBM float implementation.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import segpy.toolkit as toolkit
+import test.util
 
 
 @pytest.fixture(params=[True, False])
@@ -7,9 +7,5 @@ def ibm_floating_point_impls(request):
     """Configure segpy to run with and without the C++ implementation of IBM
     floating point un/packing.
     """
-    orig = toolkit.force_python_ibm_floats
-    toolkit.force_python_ibm_floats = request.param
-    try:
-        yield request.param
-    finally:
-        toolkit.force_python_ibm_floats = orig
+    with test.util.force_python_ibm_float(request.param) as force:
+        yield force

--- a/test/util.py
+++ b/test/util.py
@@ -1,0 +1,15 @@
+from contextlib import contextmanager
+import segpy.toolkit as toolkit
+
+
+@contextmanager
+def force_python_ibm_float(force):
+    """Configure segpy to run with and without the C++ implementation of IBM
+    floating point un/packing.
+    """
+    orig = toolkit.force_python_ibm_floats
+    toolkit.force_python_ibm_floats = force
+    try:
+        yield force
+    finally:
+        toolkit.force_python_ibm_floats = orig


### PR DESCRIPTION
This verifies that a) the Python versions of the functions are used when forced
and b) that the C++ versions are used when expected.

If the C++ extension is not installed when these tests are run, then some tests are skipped. Likewise, if the extension is installed then other tests are skipped (since they wouldn't make any sense). As such, we should eventually create a test system that first runs the tests without the extension installed, then installs the extension and runs them again. 