### PR TITLE
A few minor style cleanups.

### DIFF
--- a/examples/check_equal.py
+++ b/examples/check_equal.py
@@ -32,7 +32,7 @@ with open(out_filename, 'wb') as out_file:
     write_segy(out_file, segy_reader_in, trace_header_format=CustomTraceHeader)
 
 out_file = open(out_filename, 'rb')
-segy_reader_out = create_reader(in_file, trace_header_format=CustomTraceHeader)
+segy_reader_out = create_reader(out_file, trace_header_format=CustomTraceHeader)
 
 for trace_index in segy_reader_in.trace_indexes():
     trace_offset = segy_reader_in._trace_offset_catalog[trace_index]
@@ -43,4 +43,4 @@ for trace_index in segy_reader_in.trace_indexes():
 
     data0 = segy_reader_in.trace_samples(trace_index)
     data1 = segy_reader_out.trace_samples(trace_index)
-    assert data0==data1
+    assert data0 == data1

--- a/segpy/cli.py
+++ b/segpy/cli.py
@@ -24,6 +24,7 @@ from docopt_subcommands import Subcommands
 
 from segpy.reader import create_reader
 
+
 def common_option_handler(config):
     log_level = config['--log-level']
     try:
@@ -35,7 +36,6 @@ def common_option_handler(config):
     handler.setLevel(log_level)
     handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
     segpy.log.addHandler(handler)
-
 
 
 commands = Subcommands(program='segpy',
@@ -107,5 +107,6 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
     commands(argv)
+
 
 __doc__ = commands.top_level_doc

--- a/segpy/header.py
+++ b/segpy/header.py
@@ -59,7 +59,6 @@ class Header:
         obj = type(self)(**fields)
         return obj
 
-
     def __copy__(self):
         return self.copy()
 
@@ -89,6 +88,7 @@ class Header:
             setattr(self, name, value)
         del state['_all_attributes']
         self.__dict__.update(state)
+
 
 def are_equal(self, other):
     """Compare two headers for equality.

--- a/segpy/reader.py
+++ b/segpy/reader.py
@@ -16,7 +16,7 @@ from segpy.encoding import ASCII
 from segpy.packer import make_header_packer
 from segpy.trace_header import TraceHeaderRev1
 from segpy.util import file_length, filename_from_handle, make_sorted_distinct_sequence, hash_for_file, UNKNOWN_FILENAME
-from segpy.datatypes import DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE, SEG_Y_TYPE_DESCRIPTION, SEG_Y_TYPE_TO_CTYPE, size_in_bytes
+from segpy.datatypes import SEG_Y_TYPE_TO_CTYPE, size_in_bytes
 from segpy.toolkit import (extract_revision,
                            bytes_per_sample,
                            read_binary_reel_header,
@@ -32,6 +32,7 @@ from segpy.toolkit import (extract_revision,
 
 log = logging.getLogger(__name__)
 log.setLevel('INFO')
+
 
 def create_reader(
         fh,
@@ -224,7 +225,7 @@ def _load_reader_from_cache(cache_file_path, seg_y_path):
                 cache_file_path.unlink()
             except OSError as os_error:
                 log.warn("Could not remove stale cache entry {} for {} because {}"
-                      .format(cache_file_path, seg_y_path, os_error))
+                         .format(cache_file_path, seg_y_path, os_error))
             else:
                 log.info("Removed stale cache entry {} for {}".format(cache_file_path, seg_y_path))
             return None
@@ -507,7 +508,7 @@ class SegYReader(Dataset):
 
     @property
     def textual_reel_header(self):
-        """The textual real header as an immutable sequence of forty Unicode strings each 80 characters long.
+        """The textual reel header as an immutable sequence of forty Unicode strings each 80 characters long.
         """
         return self._textual_reel_header
 
@@ -801,4 +802,3 @@ class SegYReader2D(SegYReader):
             A trace_samples index which can be used with trace_samples().
         """
         return self._cdp_catalog[cdp_number]
-


### PR DESCRIPTION
This is primarily just PEP8-ish cleanup I made as I browsed the code. 

The only functional change is at `examples/check_equal.py:35` where I think the wrong file handle was being passed to `create_reader`. (Minus that change, I probably wouldn't have submitted this.)