### PR TITLE
Fixed bug in max_num_trace_samples for zero traces.

### DIFF
--- a/segpy/reader.py
+++ b/segpy/reader.py
@@ -415,7 +415,7 @@ class SegYReader(Dataset):
     def max_num_trace_samples(self):
         """The number of samples in the trace_samples with the most samples."""
         if self._max_num_trace_samples is None:
-            self._max_num_trace_samples = max(self._trace_length_catalog.values())
+            self._max_num_trace_samples = max(self._trace_length_catalog.values(), default=0)
         return self._max_num_trace_samples
 
     def num_trace_samples(self, trace_index):


### PR DESCRIPTION
We were calling `max()` with a potentially empty sequence, resulting in a
ValueError.