### PR TITLE
Using new, more restrictive field types for the binary header.

### DIFF
--- a/segpy/binary_reel_header.py
+++ b/segpy/binary_reel_header.py
@@ -1,9 +1,10 @@
+from segpy.datatypes import DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE
 from segpy.header import FormatMeta, field
 from segpy.field_types import IntFieldMeta, IntEnumFieldMeta, Int32, Int16, UInt32, UInt16
 
 
 class DataSampleFormatField(metaclass=IntEnumFieldMeta,
-                            values=(range(9))):
+                            values=DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE):
     pass
 
 

--- a/segpy/binary_reel_header.py
+++ b/segpy/binary_reel_header.py
@@ -1,6 +1,6 @@
 from segpy.datatypes import DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE
+from segpy.field_types import IntFieldMeta, IntEnumFieldMeta, Int32, Int16, NNInt32, NNInt16
 from segpy.header import FormatMeta, field
-from segpy.field_types import IntFieldMeta, IntEnumFieldMeta, Int32, Int16, UInt32, UInt16
 from segpy import revisions
 
 
@@ -71,7 +71,6 @@ class FormatRevisionNumField(metaclass=IntEnumFieldMeta,
     pass
 
 
-
 class BinaryReelHeader(metaclass=FormatMeta):
 
     START_OFFSET_IN_BYTES = 3201
@@ -82,7 +81,7 @@ class BinaryReelHeader(metaclass=FormatMeta):
         "Job identification number")
 
     line_num = field(
-        UInt32, offset=3205, default=0, documentation=
+        NNInt32, offset=3205, default=0, documentation=
         "Line number. For 3-D poststack data, this will typically contain the in-line number."
     )
 
@@ -92,34 +91,34 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     data_traces_per_ensemble = field(
-        UInt16, offset=3213, default=0, documentation=
+        NNInt16, offset=3213, default=0, documentation=
         "Number of data traces per ensemble. Mandatory for prestack data."
     )
 
     auxiliary_traces_per_ensemble = field(
-        UInt16, offset=3215, default=0, documentation=
+        NNInt16, offset=3215, default=0, documentation=
         "Number of auxiliary traces per ensemble. Mandatory for prestack data."
     )
 
     sample_interval = field(
-        UInt16, offset=3217, default=0, documentation=
+        NNInt16, offset=3217, default=0, documentation=
         "Sample interval in microseconds (μs). Mandatory for all data types."
     )
 
     original_field_sample_interval = field(
-        UInt16, offset=3219, default=0, documentation=
+        NNInt16, offset=3219, default=0, documentation=
         "Sample interval in microseconds (μs) of original field recording."
     )
 
     num_samples = field(
-        UInt16, offset=3221, default=0, documentation=
+        NNInt16, offset=3221, default=0, documentation=
         "Number of samples per data trace. Mandatory for all types of data. "
         "Note: The sample interval and number of samples in the Binary File Header should be for the primary set of "
         "seismic data traces in the file."
     )
 
     original_field_num_samples = field(
-        UInt16, offset=3223, default=0, documentation=
+        NNInt16, offset=3223, default=0, documentation=
         "Number of samples per data trace for original field recording."
     )
 
@@ -137,7 +136,7 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     ensemble_fold = field(
-        UInt16, offset=3227, default=0, documentation=
+        NNInt16, offset=3227, default=0, documentation=
         "Ensemble fold. The expected number of data traces per trace ensemble (e.g. the CMP fold). "
         "Highly recommended for all types of data."
     )
@@ -159,7 +158,7 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     vertical_sum_code = field(
-        UInt16, offset=3231, default=0, documentation=
+        NNInt16, offset=3231, default=0, documentation=
         "Vertical sum code: "
         "1 = no sum, "
         "2 = two sum, "
@@ -168,17 +167,17 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     sweep_frequency_at_start = field(
-        UInt16, offset=3233, default=0, documentation=
+        NNInt16, offset=3233, default=0, documentation=
         "Sweep frequency at start (Hz)."
     )
 
     sweep_frequency_at_end = field(
-        UInt16, offset=3235, default=0, documentation=
+        NNInt16, offset=3235, default=0, documentation=
         "Sweep frequency at end (Hz)."
     )
 
     sweep_length = field(
-        UInt16, offset=3237, default=0, documentation=
+        NNInt16, offset=3237, default=0, documentation=
         "Sweep length in milliseconds."
     )
 
@@ -193,12 +192,12 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     sweep_trace_taper_length_at_start = field(
-        UInt16, offset=3243, default=0, documentation=
+        NNInt16, offset=3243, default=0, documentation=
         "Sweep trace taper length at start in milliseconds."
     )
 
     sweep_trace_taper_length_at_end = field(
-        UInt16, offset=3245, default=0, documentation=
+        NNInt16, offset=3245, default=0, documentation=
         "Sweep trace taper length at end in milliseconds."
     )
 

--- a/segpy/binary_reel_header.py
+++ b/segpy/binary_reel_header.py
@@ -1,6 +1,7 @@
 from segpy.datatypes import DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE
 from segpy.header import FormatMeta, field
 from segpy.field_types import IntFieldMeta, IntEnumFieldMeta, Int32, Int16, UInt32, UInt16
+from segpy import revisions
 
 
 class DataSampleFormatField(metaclass=IntEnumFieldMeta,
@@ -66,7 +67,7 @@ class NumExtendedTextualHeadersField(metaclass=IntFieldMeta,
 
 class FormatRevisionNumField(metaclass=IntEnumFieldMeta,
                              seg_y_type='int16',
-                             values=(0x0100, 0x0000)):
+                             values=set(revisions.VARIANTS.values())):
     pass
 
 

--- a/segpy/binary_reel_header.py
+++ b/segpy/binary_reel_header.py
@@ -1,5 +1,73 @@
 from segpy.header import FormatMeta, field
-from segpy.field_types import Int32, Int16
+from segpy.field_types import IntFieldMeta, IntEnumFieldMeta, Int32, Int16, UInt32, UInt16
+
+
+class DataSampleFormatField(metaclass=IntEnumFieldMeta,
+                            values=(range(9))):
+    pass
+
+
+class TraceSortingField(metaclass=IntEnumFieldMeta,
+                        values=range(-1, 10)):
+    pass
+
+
+class SweepTypeField(metaclass=IntEnumFieldMeta,
+                     values=range(5)):
+    pass
+
+
+class TaperTypeField(metaclass=IntEnumFieldMeta,
+                     values=range(4)):
+    pass
+
+
+class CorrelatedDataTracesField(metaclass=IntEnumFieldMeta,
+                                values=range(3)):
+    pass
+
+
+class BinaryGainRecoveredField(metaclass=IntEnumFieldMeta,
+                               values=range(3)):
+    pass
+
+
+class AmplitudeRecoveryMethodField(metaclass=IntEnumFieldMeta,
+                                   values=range(5)):
+    pass
+
+
+class MeasurementSystemField(metaclass=IntEnumFieldMeta,
+                             values=range(3)):
+    pass
+
+
+class ImpulseSignalPolarityField(metaclass=IntEnumFieldMeta,
+                                 values=range(3)):
+    pass
+
+
+class VibratoryPolarityCodeField(metaclass=IntEnumFieldMeta,
+                                 values=range(9)):
+    pass
+
+
+class FixedLengthTraceFlag(metaclass=IntEnumFieldMeta,
+                           values=range(2)):
+    pass
+
+
+class NumExtendedTextualHeadersField(metaclass=IntFieldMeta,
+                                     seg_y_type='int16',
+                                     min_value=-1):
+    pass
+
+
+class FormatRevisionNumField(metaclass=IntEnumFieldMeta,
+                             seg_y_type='int16',
+                             values=(0x0100, 0x0000)):
+    pass
+
 
 
 class BinaryReelHeader(metaclass=FormatMeta):
@@ -12,7 +80,7 @@ class BinaryReelHeader(metaclass=FormatMeta):
         "Job identification number")
 
     line_num = field(
-        Int32, offset=3205, default=0, documentation=
+        UInt32, offset=3205, default=0, documentation=
         "Line number. For 3-D poststack data, this will typically contain the in-line number."
     )
 
@@ -22,39 +90,39 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     data_traces_per_ensemble = field(
-        Int16, offset=3213, default=0, documentation=
+        UInt16, offset=3213, default=0, documentation=
         "Number of data traces per ensemble. Mandatory for prestack data."
     )
 
     auxiliary_traces_per_ensemble = field(
-        Int16, offset=3215, default=0, documentation=
+        UInt16, offset=3215, default=0, documentation=
         "Number of auxiliary traces per ensemble. Mandatory for prestack data."
     )
 
     sample_interval = field(
-        Int16, offset=3217, default=0, documentation=
+        UInt16, offset=3217, default=0, documentation=
         "Sample interval in microseconds (μs). Mandatory for all data types."
     )
 
     original_field_sample_interval = field(
-        Int16, offset=3219, default=0, documentation=
+        UInt16, offset=3219, default=0, documentation=
         "Sample interval in microseconds (μs) of original field recording."
     )
 
     num_samples = field(
-        Int16, offset=3221, default=0, documentation=
+        UInt16, offset=3221, default=0, documentation=
         "Number of samples per data trace. Mandatory for all types of data. "
         "Note: The sample interval and number of samples in the Binary File Header should be for the primary set of "
         "seismic data traces in the file."
     )
 
     original_field_num_samples = field(
-        Int16, offset=3223, default=0, documentation=
+        UInt16, offset=3223, default=0, documentation=
         "Number of samples per data trace for original field recording."
     )
 
     data_sample_format = field(
-        Int16, offset=3225, default=5, documentation=
+        DataSampleFormatField, offset=3225, default=5, documentation=
         "Data sample format code. Mandatory for all data. "
         "1 = 4-byte IBM floating-point, "
         "2 = 4-byte, two's complement integer, "
@@ -67,13 +135,13 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     ensemble_fold = field(
-        Int16, offset=3227, default=0, documentation=
+        UInt16, offset=3227, default=0, documentation=
         "Ensemble fold. The expected number of data traces per trace ensemble (e.g. the CMP fold). "
         "Highly recommended for all types of data."
     )
 
     trace_sorting = field(
-        Int16, offset=3229, default=0, documentation=
+        TraceSortingField, offset=3229, default=0, documentation=
         "Trace sorting code (i.e. type of ensemble) : "
         "-1 = Other (should be explained in user Extended Textual File Header stanza, "
         "0 = Unknown, "
@@ -89,7 +157,7 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     vertical_sum_code = field(
-        Int16, offset=3231, default=0, documentation=
+        UInt16, offset=3231, default=0, documentation=
         "Vertical sum code: "
         "1 = no sum, "
         "2 = two sum, "
@@ -98,22 +166,22 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     sweep_frequency_at_start = field(
-        Int16, offset=3233, default=0, documentation=
+        UInt16, offset=3233, default=0, documentation=
         "Sweep frequency at start (Hz)."
     )
 
     sweep_frequency_at_end = field(
-        Int16, offset=3235, default=0, documentation=
+        UInt16, offset=3235, default=0, documentation=
         "Sweep frequency at end (Hz)."
     )
 
     sweep_length = field(
-        Int16, offset=3237, default=0, documentation=
+        UInt16, offset=3237, default=0, documentation=
         "Sweep length in milliseconds."
     )
 
     sweep_type = field(
-        Int16, offset=3239, default=0, documentation=
+        SweepTypeField, offset=3239, default=0, documentation=
         "Sweep type: 1 = linear, 2 = parabolic, 3 = exponential 4 = other."
     )
 
@@ -123,36 +191,36 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     sweep_trace_taper_length_at_start = field(
-        Int16, offset=3243, default=0, documentation=
+        UInt16, offset=3243, default=0, documentation=
         "Sweep trace taper length at start in milliseconds."
     )
 
     sweep_trace_taper_length_at_end = field(
-        Int16, offset=3245, default=0, documentation=
+        UInt16, offset=3245, default=0, documentation=
         "Sweep trace taper length at end in milliseconds."
     )
 
     taper_type = field(
-        Int16, offset=3247, default=0, documentation=
+        TaperTypeField, offset=3247, default=0, documentation=
         "Taper type: 1 = linear, 2 = cos2, 3 = other"
     )
 
     correlated_data_traces = field(
-        Int16, offset=3249, default=0, documentation=
+        CorrelatedDataTracesField, offset=3249, default=0, documentation=
         "Correlated data traces: "
         "1 = no, "
         "2 = yes"
     )
 
     binary_gain_recovered = field(
-        Int16, offset=3251, default=0, documentation=
+        BinaryGainRecoveredField, offset=3251, default=0, documentation=
         "Binary gain recovered: "
         "1 = no, "
         "2 = yes"
     )
 
     amplitude_recovery_method = field(
-        Int16, offset=3253, default=0, documentation=
+        AmplitudeRecoveryMethodField, offset=3253, default=0, documentation=
         "Amplitude recovery method: "
         "1 = none, "
         "2 = spherical divergence, "
@@ -161,7 +229,7 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     measurement_system = field(
-        Int16, offset=3255, default=0, documentation=
+        MeasurementSystemField, offset=3255, default=0, documentation=
         "Measurement system: Highly recommended for all types of data. "
         "If Location Data stanzas are included in the file, this entry must agree with the Location Data stanza. "
         "If there is a disagreement, the last Location Data stanza is the controlling authority. "
@@ -170,14 +238,15 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     impulse_signal_polarity = field(
-        Int16, offset=3257, default=0, documentation=
+        ImpulseSignalPolarityField, offset=3257, default=0, documentation=
         "Impulse signal polarity : "
         "1 = Increase in pressure or upward geophone case movement gives negative number on tape, "
         "2 = Increase in pressure or upward geophone case movement gives positive number on tape. "
     )
 
     vibratory_polarity_code = field(
-        Int16, offset=3259, default=0, documentation=
+        VibratoryPolarityCodeField,
+        offset=3259, default=0, documentation=
         "Vibratory polarity code: "
         "Seismic signal lags pilot signal by: "
         "1 = 337.5° to 22.5°, "
@@ -190,7 +259,7 @@ class BinaryReelHeader(metaclass=FormatMeta):
         "8 = 292.5° to 337.5°.")
 
     format_revision_num = field(
-        Int16, offset=3501, default=0x100, documentation=
+        FormatRevisionNumField, offset=3501, default=0x100, documentation=
         "SEG Y Format Revision Number. "
         "This is a 16-bit unsigned value with a Q- point between the first and second bytes. "
         "Thus for SEG Y Revision 1.0, as defined in this document, this will be recorded as 010016. This field is "
@@ -199,7 +268,7 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     fixed_length_trace_flag = field(
-        Int16, offset=3503, default=0, documentation=
+        FixedLengthTraceFlag, offset=3503, default=0, documentation=
         "Fixed length trace flag. A value of one indicates that all traces in this SEG Y file are guaranteed to have "
         "the same sample interval and number of samples, as specified in Textual File Header bytes 3217-3218 and "
         "3221-3222. A value of zero indicates that the length of the traces in the file may vary and the number of "
@@ -209,7 +278,7 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     num_extended_textual_headers = field(
-        Int16, offset=3505, default=0, documentation=
+        NumExtendedTextualHeadersField, offset=3505, default=0, documentation=
         "Number of 3200-byte, Extended Textual File Header records following the Binary Header. "
         "A value of zero indicates there are no Extended Textual File Header records (i.e. this file has no Extended "
         "Textual File Header(s)). A value of -1 indicates that there are a variable number of Extended Textual File "
@@ -220,4 +289,3 @@ class BinaryReelHeader(metaclass=FormatMeta):
         "that a positive value be recorded here. This field is mandatory for all versions of SEG Y, although a value "
         "of zero indicates “traditional” SEG Y conforming to the 1975 standard."
     )
-

--- a/segpy/binary_reel_header.py
+++ b/segpy/binary_reel_header.py
@@ -1,61 +1,208 @@
-from segpy.datatypes import DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE
+from enum import IntEnum
+
+from segpy.datatypes import DataSampleFormat
 from segpy.field_types import IntFieldMeta, IntEnumFieldMeta, Int32, Int16, NNInt32, NNInt16
 from segpy.header import FormatMeta, field
 from segpy import revisions
 
 
 class DataSampleFormatField(metaclass=IntEnumFieldMeta,
-                            values=DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE):
+                            enum=DataSampleFormat):
     pass
+
+
+class TraceSorting(IntEnum):
+    """Trace sorting code (i.e. type of ensemble) :
+    -1 = Other (should be explained in user Extended Textual File Header stanza,
+    0 = Unknown,
+    1 = As recorded (no sorting),
+    2 = CDP ensemble,
+    3 = Single fold continuous profile 4 = Horizontally stacked,
+    5 = Common source point,
+    6 = Common receiver point,
+    7 = Common offset point,
+    8 = Common mid-point,
+    9 = Common conversion point.
+    Highly recommended for all types of data.
+    """
+    OTHER = -1
+    UNKNOWN = 0
+    AS_RECORDED = 1
+    CDP_ENSEMBLE = 2
+    SINGLE_FOLD_CONTINUOUS_PROFILE = 3
+    HORIZONTALLY_STACKED = 4
+    COMMON_SOURCE_POINT = 5
+    COMMON_RECEIVER_POINT = 6
+    COMMON_OFFSET_POINT = 7
+    COMMON_MIDPOINT = 8
+    COMMON_CONVERSION_POINT = 9
 
 
 class TraceSortingField(metaclass=IntEnumFieldMeta,
-                        values=range(-1, 10)):
+                        enum=TraceSorting):
     pass
+
+
+class SweepType(IntEnum):
+    """Sweep type:
+    1 = linear,
+    2 = parabolic,
+    3 = exponential
+    4 = other.
+    """
+    UNKNOWN = 0
+    LINEAR = 1
+    PARABOLIC = 2
+    EXPONENTIAL = 3
+    OTHER = 4
 
 
 class SweepTypeField(metaclass=IntEnumFieldMeta,
-                     values=range(5)):
+                     enum=SweepType):
     pass
+
+
+class TaperType(IntEnum):
+    """Taper type:
+    1 = linear,
+    2 = cos2,
+    3 = other
+    """
+    UNKNOWN = 0
+    LINEAR = 1
+    COS_SQUARED = 2
+    OTHER = 3
 
 
 class TaperTypeField(metaclass=IntEnumFieldMeta,
-                     values=range(4)):
+                     enum=TaperType):
     pass
+
+
+class CorrelatedDataTraces(IntEnum):
+    """Correlated data traces:
+    1 = no,
+    2 = yes
+    """
+    UNKNOWN = 0
+    NO = 1
+    YES = 2
 
 
 class CorrelatedDataTracesField(metaclass=IntEnumFieldMeta,
-                                values=range(3)):
+                                enum=CorrelatedDataTraces):
     pass
+
+
+class BinaryGainRecovered(IntEnum):
+    """Binary gain recovered:
+    1 = no,
+    2 = yes
+    """
+    UNKNOWN = 0
+    YES = 1
+    NO = 2
 
 
 class BinaryGainRecoveredField(metaclass=IntEnumFieldMeta,
-                               values=range(3)):
+                               enum=BinaryGainRecovered):
     pass
+
+
+class AmplitudeRecoveryMethod(IntEnum):
+    """Amplitude recovery method:
+    1 = none,
+    2 = spherical divergence,
+    3 = AGC,
+    4 = other
+    """
+    UNKNOWN = 0
+    NONE = 1
+    SPHERICAL_DIVERGENCE = 2
+    AGC = 3
+    OTHER = 4
 
 
 class AmplitudeRecoveryMethodField(metaclass=IntEnumFieldMeta,
-                                   values=range(5)):
+                                   enum=AmplitudeRecoveryMethod):
     pass
+
+
+class MeasurementSystem(IntEnum):
+    """Measurement system: Highly recommended for all types of data.
+    If Location Data stanzas are included in the file, this entry must agree with the Location Data stanza.
+    If there is a disagreement, the last Location Data stanza is the controlling authority.
+    1 = Meters,
+    2 = Feet
+    """
+    UNKNOWN = 0
+    METERS = 1
+    FEET = 2
 
 
 class MeasurementSystemField(metaclass=IntEnumFieldMeta,
-                             values=range(3)):
+                             enum=MeasurementSystem):
     pass
+
+
+class ImpulseSignalPolarity(IntEnum):
+    """Impulse signal polarity :
+    1 = Increase in pressure or upward geophone case movement gives negative number on tape,
+    2 = Increase in pressure or upward geophone case movement gives positive number on tape.
+    """
+    UNKNOWN = 0
+    INCREASE_GIVES_NEGATIVE_ON_TAPE = 1
+    INCREASE_GIVES_POSITIVE_ON_TAPE = 2
 
 
 class ImpulseSignalPolarityField(metaclass=IntEnumFieldMeta,
-                                 values=range(3)):
+                                 enum=ImpulseSignalPolarity):
     pass
+
+
+class VibratoryPolarityCode(IntEnum):
+    """Seismic signal lags pilot signal by:
+    1 = 337.5° to 22.5°,
+    2 = 22.5° to 67.5°,
+    3 = 67.5° to 112.5°,
+    4 = 112.5° to 157.5°,
+    5 = 157.5° to 202.5°,
+    6 = 202.5°to 247.5°,
+    7 = 247.5° to 292.5°,
+    8 = 292.5° to 337.5°.
+    """
+    UNKNOWN = 0
+    FROM_337_5_TO_22_5 = 1
+    FROM_22_5_TO_67_5 = 2
+    FROM_67_5_TO_112_5 = 3
+    FROM_112_5_TO_157_5 = 4
+    FROM_157_5_TO_202_5 = 5
+    FROM_202_5_TO_247_5 = 6
+    FROM_247_5_TO_292_5 = 7
+    FROM_292_5_TO_337_5 = 8
 
 
 class VibratoryPolarityCodeField(metaclass=IntEnumFieldMeta,
-                                 values=range(9)):
+                                 enum=VibratoryPolarityCode):
     pass
 
 
-class FixedLengthTraceFlag(metaclass=IntEnumFieldMeta,
-                           values=range(2)):
+class FixedLengthTraceFlag(IntEnum):
+    """Fixed length trace flag. A value of one indicates that all traces in this
+    SEG Y file are guaranteed to have the same sample interval and number of
+    samples, as specified in Textual File Header bytes 3217-3218 and 3221-3222.
+    A value of zero indicates that the length of the traces in the file may
+    vary and the number of samples in bytes 115-116 of the Trace Header must be
+    examined to determine the actual length of each trace. This field is
+    mandatory for all versions of SEG Y, although a value of zero indicates
+    “traditional” SEG Y conforming to the 1975 standard.
+    """
+    VARIABLE_LENGTH = 0
+    FIXED_LENGTH = 1
+
+
+class FixedLengthTraceFlagField(metaclass=IntEnumFieldMeta,
+                                enum=FixedLengthTraceFlag):
     pass
 
 
@@ -66,8 +213,7 @@ class NumExtendedTextualHeadersField(metaclass=IntFieldMeta,
 
 
 class FormatRevisionNumField(metaclass=IntEnumFieldMeta,
-                             seg_y_type='int16',
-                             values=set(revisions.VARIANTS.values())):
+                             enum=revisions.SegYRevision):
     pass
 
 
@@ -112,9 +258,9 @@ class BinaryReelHeader(metaclass=FormatMeta):
 
     num_samples = field(
         NNInt16, offset=3221, default=0, documentation=
-        "Number of samples per data trace. Mandatory for all types of data. "
-        "Note: The sample interval and number of samples in the Binary File Header should be for the primary set of "
-        "seismic data traces in the file."
+        """Number of samples per data trace. Mandatory for all types of data.
+        Note: The sample interval and number of samples in the Binary File Header should be for the primary set of
+        seismic data traces in the file."""
     )
 
     original_field_num_samples = field(
@@ -123,47 +269,27 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     data_sample_format = field(
-        DataSampleFormatField, offset=3225, default=5, documentation=
-        "Data sample format code. Mandatory for all data. "
-        "1 = 4-byte IBM floating-point, "
-        "2 = 4-byte, two's complement integer, "
-        "3 = 2-byte, two's complement integer, "
-        "4 = 4-byte fixed-point with gain (obsolete), "
-        "5 = 4-byte IEEE floating-point, "
-        "6 = Not currently used, "
-        "7 = Not currently used, "
-        "8 = 1-byte, two's complement integer."
+        DataSampleFormatField, offset=3225, default=5,
+        documentation=DataSampleFormat.__doc__
     )
 
     ensemble_fold = field(
         NNInt16, offset=3227, default=0, documentation=
-        "Ensemble fold. The expected number of data traces per trace ensemble (e.g. the CMP fold). "
-        "Highly recommended for all types of data."
+        """Ensemble fold. The expected number of data traces per trace ensemble (e.g. the CMP fold).
+        Highly recommended for all types of data."""
     )
 
     trace_sorting = field(
-        TraceSortingField, offset=3229, default=0, documentation=
-        "Trace sorting code (i.e. type of ensemble) : "
-        "-1 = Other (should be explained in user Extended Textual File Header stanza, "
-        "0 = Unknown, "
-        "1 = As recorded (no sorting), "
-        "2 = CDP ensemble, "
-        "3 = Single fold continuous profile 4 = Horizontally stacked, "
-        "5 = Common source point, "
-        "6 = Common receiver point, "
-        "7 = Common offset point, "
-        "8 = Common mid-point, "
-        "9 = Common conversion point. "
-        "Highly recommended for all types of data."
-    )
+        TraceSortingField, offset=3229, default=0,
+        documentation=TraceSorting.__doc__)
 
     vertical_sum_code = field(
         NNInt16, offset=3231, default=0, documentation=
-        "Vertical sum code: "
-        "1 = no sum, "
-        "2 = two sum, "
-        "..., "
-        "N=M-1 sum (M=2to32,767)."
+        """Vertical sum code:
+        1 = no sum,
+        2 = two sum,
+        ...,
+        N=M-1 sum (M=2to32,767)."""
     )
 
     sweep_frequency_at_start = field(
@@ -182,8 +308,8 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     sweep_type = field(
-        SweepTypeField, offset=3239, default=0, documentation=
-        "Sweep type: 1 = linear, 2 = parabolic, 3 = exponential 4 = other."
+        SweepTypeField, offset=3239, default=0,
+        documentation=SweepType.__doc__
     )
 
     sweep_trace_number = field(
@@ -202,91 +328,69 @@ class BinaryReelHeader(metaclass=FormatMeta):
     )
 
     taper_type = field(
-        TaperTypeField, offset=3247, default=0, documentation=
-        "Taper type: 1 = linear, 2 = cos2, 3 = other"
+        TaperTypeField, offset=3247, default=0,
+        documentation=TaperType.__doc__
     )
 
     correlated_data_traces = field(
-        CorrelatedDataTracesField, offset=3249, default=0, documentation=
-        "Correlated data traces: "
-        "1 = no, "
-        "2 = yes"
+        CorrelatedDataTracesField, offset=3249, default=0,
+        documentation=CorrelatedDataTraces.__doc__
     )
 
     binary_gain_recovered = field(
-        BinaryGainRecoveredField, offset=3251, default=0, documentation=
-        "Binary gain recovered: "
-        "1 = no, "
-        "2 = yes"
+        BinaryGainRecoveredField, offset=3251, default=0,
+        documentation=BinaryGainRecovered.__doc__
     )
 
     amplitude_recovery_method = field(
-        AmplitudeRecoveryMethodField, offset=3253, default=0, documentation=
-        "Amplitude recovery method: "
-        "1 = none, "
-        "2 = spherical divergence, "
-        "3 = AGC, "
-        "4 = other"
+        AmplitudeRecoveryMethodField, offset=3253, default=0,
+        documentation=AmplitudeRecoveryMethod.__doc__
     )
 
     measurement_system = field(
-        MeasurementSystemField, offset=3255, default=0, documentation=
-        "Measurement system: Highly recommended for all types of data. "
-        "If Location Data stanzas are included in the file, this entry must agree with the Location Data stanza. "
-        "If there is a disagreement, the last Location Data stanza is the controlling authority. "
-        "1 = Meters, "
-        "2 = Feet"
+        MeasurementSystemField, offset=3255, default=0,
+        documentation=MeasurementSystem.__doc__
     )
 
     impulse_signal_polarity = field(
-        ImpulseSignalPolarityField, offset=3257, default=0, documentation=
-        "Impulse signal polarity : "
-        "1 = Increase in pressure or upward geophone case movement gives negative number on tape, "
-        "2 = Increase in pressure or upward geophone case movement gives positive number on tape. "
+        ImpulseSignalPolarityField, offset=3257, default=0,
+        documentation=ImpulseSignalPolarity.__doc__
     )
 
     vibratory_polarity_code = field(
         VibratoryPolarityCodeField,
-        offset=3259, default=0, documentation=
-        "Vibratory polarity code: "
-        "Seismic signal lags pilot signal by: "
-        "1 = 337.5° to 22.5°, "
-        "2 = 22.5° to 67.5°, "
-        "3 = 67.5° to 112.5°, "
-        "4 = 112.5° to 157.5°, "
-        "5 = 157.5° to 202.5°, "
-        "6 = 202.5°to 247.5°,  "
-        "7 = 247.5° to 292.5°, "
-        "8 = 292.5° to 337.5°.")
+        offset=3259, default=0,
+        documentation=VibratoryPolarityCode.__doc__
+    )
 
     format_revision_num = field(
         FormatRevisionNumField, offset=3501, default=0x100, documentation=
-        "SEG Y Format Revision Number. "
-        "This is a 16-bit unsigned value with a Q- point between the first and second bytes. "
-        "Thus for SEG Y Revision 1.0, as defined in this document, this will be recorded as 010016. This field is "
-        "mandatory for all versions of SEG Y, although a value of zero indicates “traditional” SEG Y conforming to "
-        "the 1975 standard."
+        """SEG Y Format Revision Number. This is a 16-bit unsigned value with a Q-
+        point between the first and second bytes. Thus for SEG Y Revision 1.0,
+        as defined in this document, this will be recorded as 010016. This
+        field is mandatory for all versions of SEG Y, although a value of zero
+        indicates “traditional” SEG Y conforming to the 1975 standard."""
     )
 
     fixed_length_trace_flag = field(
-        FixedLengthTraceFlag, offset=3503, default=0, documentation=
-        "Fixed length trace flag. A value of one indicates that all traces in this SEG Y file are guaranteed to have "
-        "the same sample interval and number of samples, as specified in Textual File Header bytes 3217-3218 and "
-        "3221-3222. A value of zero indicates that the length of the traces in the file may vary and the number of "
-        "samples in bytes 115-116 of the Trace Header must be examined to determine the actual length of each trace. "
-        "This field is mandatory for all versions of SEG Y, although a value of zero indicates “traditional” SEG Y "
-        "conforming to the 1975 standard."
+        FixedLengthTraceFlagField, offset=3503, default=0,
+        documentation=FixedLengthTraceFlag.__doc__
     )
 
     num_extended_textual_headers = field(
         NumExtendedTextualHeadersField, offset=3505, default=0, documentation=
-        "Number of 3200-byte, Extended Textual File Header records following the Binary Header. "
-        "A value of zero indicates there are no Extended Textual File Header records (i.e. this file has no Extended "
-        "Textual File Header(s)). A value of -1 indicates that there are a variable number of Extended Textual File "
-        "Header records and the end of the Extended Textual File Header is denoted by an ((SEG: EndText)) stanza in "
-        "the final record. A positive value indicates that there are exactly that many Extended Textual File Header "
-        "records. Note that, although the exact number of Extended Textual File Header records may be a useful piece "
-        "of information, it will not always be known at the time the Binary Header is written and it is not mandatory "
-        "that a positive value be recorded here. This field is mandatory for all versions of SEG Y, although a value "
-        "of zero indicates “traditional” SEG Y conforming to the 1975 standard."
+        """Number of 3200-byte, Extended Textual File Header records following the
+        Binary Header. A value of zero indicates there are no Extended Textual
+        File Header records (i.e. this file has no Extended Textual File
+        Header(s)). A value of -1 indicates that there are a variable number of
+        Extended Textual File Header records and the end of the Extended
+        Textual File Header is denoted by an ((SEG: EndText)) stanza in the
+        final record. A positive value indicates that there are exactly that
+        many Extended Textual File Header records. Note that, although the
+        exact number of Extended Textual File Header records may be a useful
+        piece of information, it will not always be known at the time the
+        Binary Header is written and it is not mandatory that a positive value
+        be recorded here. This field is mandatory for all versions of SEG Y,
+        although a value of zero indicates “traditional” SEG Y conforming to
+        the 1975 standard."""
     )

--- a/segpy/datatypes.py
+++ b/segpy/datatypes.py
@@ -64,9 +64,12 @@ Limits = namedtuple('Limits', ['min', 'max'])
 LIMITS = {
     'ibm': Limits(MIN_IBM_FLOAT, MAX_IBM_FLOAT),
     'int32': Limits(-2147483648, 2147483647),
+    'uint32': Limits(0, 4294967295),
     'int16': Limits(-32768, 32767),
+    'uint16': Limits(0, 65535),
     'float32': Limits(-3.402823e38, 3.402823e38),
-    'int8': Limits(-128, 127)
+    'int8': Limits(-128, 127),
+    'uint8': Limits(0, 255)
 }
 
 PY_TYPES = {

--- a/segpy/datatypes.py
+++ b/segpy/datatypes.py
@@ -19,11 +19,11 @@ SEG_Y_TYPE_TO_DATA_SAMPLE_FORMAT = {v: k for k, v in DATA_SAMPLE_FORMAT_TO_SEG_Y
 # Python Standard Library struct module
 SEG_Y_TYPE_TO_CTYPE = {
     'int32':  'i',
-    'uint32': 'I',
+    'nnint32': 'I',
     'int16':  'h',
-    'uint16': 'H',
+    'nnint16': 'H',
     'int8': 'b',
-    'uint8': 'B',
+    'nnint8': 'B',
     'float32':  'f',
     'ibm': 'ibm'}
 
@@ -32,12 +32,12 @@ SEG_Y_TYPE_TO_CTYPE = {
 SEG_Y_TYPE_DESCRIPTION = {
     'ibm': 'IBM 32 bit float',
     'int32': '32 bit signed integer',
-    'uint32': '32 bit unsigned integer',
+    'nnint32': '32 bit non-negative integer',
     'int16': '16 bit signed integer',
-    'uint16': '16 bit unsigned integer',
+    'nnint16': '16 bit unsigned integer',
     'float32': 'IEEE float32',
     'int8': '8 bit signed integer (byte)',
-    'uint8': '8 bit unsigned integer (byte)'}
+    'nnint8': '8 bit unsigned integer (byte)'}
 
 # Sizes of various ctypes in bytes
 CTYPE_TO_SIZE = dict(
@@ -64,12 +64,12 @@ Limits = namedtuple('Limits', ['min', 'max'])
 LIMITS = {
     'ibm': Limits(MIN_IBM_FLOAT, MAX_IBM_FLOAT),
     'int32': Limits(-2147483648, 2147483647),
-    'uint32': Limits(0, 4294967295),
+    'nnint32': Limits(0, 2147483647),
     'int16': Limits(-32768, 32767),
-    'uint16': Limits(0, 65535),
+    'nnint16': Limits(0, 32767),
     'float32': Limits(-3.402823e38, 3.402823e38),
     'int8': Limits(-128, 127),
-    'uint8': Limits(0, 255)
+    'nnint8': Limits(0, 127)
 }
 
 PY_TYPES = {

--- a/segpy/datatypes.py
+++ b/segpy/datatypes.py
@@ -3,15 +3,34 @@
 
 # A mapping from data sample format codes to SEG Y types.
 from collections import namedtuple
+from enum import IntEnum
 
 from segpy.ibm_float import MIN_IBM_FLOAT, MAX_IBM_FLOAT
 
+
+class DataSampleFormat(IntEnum):
+    """Data sample format code. Mandatory for all data.
+    1 = 4-byte IBM floating-point,
+    2 = 4-byte, two's complement integer,
+    3 = 2-byte, two's complement integer,
+    4 = 4-byte fixed-point with gain (obsolete),
+    5 = 4-byte IEEE floating-point,
+    6 = Not currently used,
+    7 = Not currently used,
+    8 = 1-byte, two's complement integer."""
+    IBM = 1
+    INT32 = 2
+    INT16 = 3
+    FLOAT32 = 5
+    INT8 = 8
+
+
 DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE = {
-    1: 'ibm',
-    2: 'int32',
-    3: 'int16',
-    5: 'float32',
-    8: 'int8'}
+    DataSampleFormat.IBM: 'ibm',
+    DataSampleFormat.INT32: 'int32',
+    DataSampleFormat.INT16: 'int16',
+    DataSampleFormat.FLOAT32: 'float32',
+    DataSampleFormat.INT8: 'int8'}
 
 SEG_Y_TYPE_TO_DATA_SAMPLE_FORMAT = {v: k for k, v in DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE.items()}
 

--- a/segpy/field_types.py
+++ b/segpy/field_types.py
@@ -1,29 +1,86 @@
-class Int16(int):
+from .datatypes import LIMITS, SEG_Y_TYPE_TO_CTYPE, size_in_bytes
 
-    MINIMUM = -32768
-    MAXIMUM = 32767
-    SIZE = 2
-    SEG_Y_TYPE = 'int16'
 
-    def __new__(cls, *args, **kwargs):
-        instance = super().__new__(cls, *args, **kwargs)
-        if not (Int16.MINIMUM <= instance <= Int16.MAXIMUM):
-            raise ValueError("{} value {!r} outside range {} to {}".format(cls.__name__, instance,
-                                                                        cls.MINIMUM, cls.MAXIMUM))
+class IntFieldMeta(type):
+    """Metaclass for signed and unsigned int fields.
+    """
+
+    def class_new(cls, *args, **kwargs):
+        instance = super(cls, cls).__new__(cls, *args, **kwargs)
+        if not (cls.MINIMUM <= instance <= cls.MAXIMUM):
+            raise ValueError("{} value {!r} outside range {} to {}".format(
+                cls.__name__, instance,
+                cls.MINIMUM, cls.MAXIMUM))
         return instance
 
+    def __new__(cls, name, bases, namespace,
+                seg_y_type,
+                min_value=None,
+                max_value=None,
+                **kwargs):
 
-class Int32(int):
+        bases = bases + (int,)
 
-    MINIMUM = -2147483648
-    MAXIMUM = 2147483647
-    SIZE = 4
-    SEG_Y_TYPE = 'int32'
+        if min_value is None:
+            min_value = LIMITS[seg_y_type].min
 
-    def __new__(cls, *args, **kwargs):
-        instance = super().__new__(cls, *args, **kwargs)
-        if not (Int32.MINIMUM <= instance <= Int32.MAXIMUM):
-            raise ValueError("{} value {!r} outside range {} to {}".format(cls.__name__, instance,
-                                                                        cls.MINIMUM, cls.MAXIMUM))
+        if max_value is None:
+            max_value = LIMITS[seg_y_type].max
+
+        namespace.update({
+            'SEG_Y_TYPE': seg_y_type,
+            'MINIMUM': min_value,
+            'MAXIMUM': max_value,
+            'SIZE': size_in_bytes(SEG_Y_TYPE_TO_CTYPE[seg_y_type]),
+            '__new__': cls.class_new,
+        })
+        return super().__new__(cls, name, bases, namespace, **kwargs)
+
+    def __init__(cls, name, bases, namespace, *args, **kwargs):
+        super().__init__(name, bases, namespace)
+
+
+class Int16(metaclass=IntFieldMeta,
+            seg_y_type='int16'):
+    pass
+
+
+class UInt16(metaclass=IntFieldMeta,
+             seg_y_type='uint16'):
+    pass
+
+
+class Int32(metaclass=IntFieldMeta,
+            seg_y_type='int32'):
+    pass
+
+
+class UInt32(metaclass=IntFieldMeta,
+             seg_y_type='uint32'):
+    pass
+
+
+class IntEnumFieldMeta(IntFieldMeta):
+    """Metaclass for int fields which are limited to a set of values.
+    """
+
+    def class_new(cls, *args, **kwargs):
+        instance = super(cls, cls).__new__(cls, *args, **kwargs)
+        if instance not in cls.VALUES:
+            raise ValueError("{} value {!r} not in valid value set {}".format(
+                cls.__name__, instance, cls.VALUES))
         return instance
 
+    def __new__(cls, name, bases, namespace, values, seg_y_type='int16', **kwargs):
+        if any((value < LIMITS[seg_y_type].min)
+               or (value > LIMITS[seg_y_type].max)
+               for value in values):
+            raise ValueError(
+                'Enum values must be within specified SEGY field type range.')
+
+        namespace['VALUES'] = set(values)
+
+        return super().__new__(cls, name, bases, namespace, seg_y_type, **kwargs)
+
+    def __init__(cls, name, bases, namespace, *args, **kwargs):
+        super().__init__(name, bases, namespace)

--- a/segpy/field_types.py
+++ b/segpy/field_types.py
@@ -45,8 +45,8 @@ class Int16(metaclass=IntFieldMeta,
     pass
 
 
-class UInt16(metaclass=IntFieldMeta,
-             seg_y_type='uint16'):
+class NNInt16(metaclass=IntFieldMeta,
+              seg_y_type='nnint16'):
     pass
 
 
@@ -55,8 +55,8 @@ class Int32(metaclass=IntFieldMeta,
     pass
 
 
-class UInt32(metaclass=IntFieldMeta,
-             seg_y_type='uint32'):
+class NNInt32(metaclass=IntFieldMeta,
+              seg_y_type='nnint32'):
     pass
 
 

--- a/segpy/revisions.py
+++ b/segpy/revisions.py
@@ -12,16 +12,19 @@ From the specification:
 
 
 from decimal import Decimal
+from enum import IntEnum
 
 
-SEGY_REVISION_0 = 0x0000
-SEGY_REVISION_1 = 0x0100
+class SegYRevision(IntEnum):
+    REVISION_0 = 0x0000
+    REVISION_1 = 0x0100
+
 
 VARIANTS = {
-    SEGY_REVISION_0: SEGY_REVISION_0,  # Ensure that SEGY_REVISION_0 maps to itself
-    SEGY_REVISION_1: SEGY_REVISION_1,  # Ensure that SEGY_REVISION_1 maps to itself
-    1: SEGY_REVISION_1,                # Common, but erroneous, decimal one
-    100: SEGY_REVISION_1}              # Common, but erroneous, decimal one-hundred
+    SegYRevision.REVISION_0: SegYRevision.REVISION_0,  # Ensure that SEGY_REVISION_0 maps to itself
+    SegYRevision.REVISION_1: SegYRevision.REVISION_1,  # Ensure that SEGY_REVISION_1 maps to itself
+    1: SegYRevision.REVISION_1,                # Common, but erroneous, decimal one
+    100: SegYRevision.REVISION_1}              # Common, but erroneous, decimal one-hundred
 
 
 class SegYRevisionError(Exception):

--- a/segpy/textual_reel_header.py
+++ b/segpy/textual_reel_header.py
@@ -1,4 +1,4 @@
-from segpy.revisions import SEGY_REVISION_0, SEGY_REVISION_1
+from segpy.revisions import SegYRevision
 
 # Do not use _TEMPLATE directly. Prefer to use TEMPLATE defined below which is
 # stripped of line endings.
@@ -50,8 +50,8 @@ TEMPLATE = ''.join(_TEMPLATE.splitlines(keepends=False)[1:])
 END_TEXTUAL_HEADER = 'END TEXTUAL HEADER'
 END_EBCDIC = 'END EBCDIC'
 
-END_MARKERS = {SEGY_REVISION_0: END_EBCDIC,
-               SEGY_REVISION_1: END_TEXTUAL_HEADER}
+END_MARKERS = {SegYRevision.REVISION_0: END_EBCDIC,
+               SegYRevision.REVISION_1: END_TEXTUAL_HEADER}
 
 TEMPLATE_FIELD_NAMES = {'client': 'client',
                         'company': 'company',

--- a/test/strategies.py
+++ b/test/strategies.py
@@ -62,8 +62,8 @@ def header(header_class, **kwargs):
             field_strategy = just(kwargs.pop(field_name))
         else:
             value_type = getattr(header_class, field_name).value_type
-            if hasattr(value_type, 'VALUES'):
-                field_strategy = sampled_from(sorted(value_type.VALUES))
+            if hasattr(value_type, 'ENUM'):
+                field_strategy = sampled_from(sorted(value_type.ENUM))
             else:
                 field_strategy = integers(value_type.MINIMUM, value_type.MAXIMUM)
         field_strategies[field_name] = field_strategy

--- a/test/strategies.py
+++ b/test/strategies.py
@@ -4,7 +4,6 @@ from itertools import accumulate, starmap, product
 import sys
 from hypothesis import assume
 from hypothesis.strategies import integers, just, fixed_dictionaries, lists, text, composite, sampled_from
-from segpy.trace_header import TraceHeaderRev0
 from segpy.util import batched
 
 PRINTABLE_ASCII_RANGE = (32, 127)
@@ -63,7 +62,10 @@ def header(header_class, **kwargs):
             field_strategy = just(kwargs.pop(field_name))
         else:
             value_type = getattr(header_class, field_name).value_type
-            field_strategy = integers(value_type.MINIMUM, value_type.MAXIMUM)
+            if hasattr(value_type, 'VALUES'):
+                field_strategy = sampled_from(sorted(value_type.VALUES))
+            else:
+                field_strategy = integers(value_type.MINIMUM, value_type.MAXIMUM)
         field_strategies[field_name] = field_strategy
 
     if len(kwargs) > 0:

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -6,7 +6,7 @@ from segpy import textual_reel_header
 from segpy.binary_reel_header import BinaryReelHeader
 from segpy.encoding import ASCII, EBCDIC
 from segpy.header import are_equal
-from segpy.revisions import SEGY_REVISION_0, SEGY_REVISION_1
+from segpy.revisions import SegYRevision
 from segpy.toolkit import write_binary_reel_header, read_binary_reel_header, write_textual_reel_header, \
     read_textual_reel_header, CARDS_PER_HEADER, CARD_LENGTH, format_standard_textual_header, \
     parse_standard_textual_header
@@ -71,7 +71,7 @@ class TestTextualReelHeader:
         assert all(len(line) == CARD_LENGTH for line in read_header_lines)
 
     @given(write_header_fields=fixed_dict_of_printable_strings(textual_reel_header.TEMPLATE_FIELD_NAMES.values()),
-           revision=sampled_from([SEGY_REVISION_0, SEGY_REVISION_1]),
+           revision=sampled_from([SegYRevision.REVISION_0, SegYRevision.REVISION_1]),
            encoding=sampled_from([ASCII, EBCDIC]))
     @settings(suppress_health_check=(HealthCheck.too_slow,))
     def test_header_template(self, write_header_fields, revision, encoding):


### PR DESCRIPTION
For example, we're using unsigned field types where appropriate to help avoid
problems with physically impossible negative values.

The place to start with this review is in `field_types.py` where we define some new metaclasses to simplify the creation of various int-related field types.

Then look in `binary_reel_header.py` to see how the new metaclasses are applied.