### PR TITLE
Added test for round-tripping a dataset

### DIFF
--- a/segpy/reader.py
+++ b/segpy/reader.py
@@ -264,6 +264,11 @@ def _make_reader(fh, encoding, trace_header_format, endian, progress, dimensiona
 
     assert 1 <= dimensionality <= 3
 
+    trace_offset_catalog, trace_length_catalog, cdp_catalog, line_catalog = tuple(
+        catalog or {}
+        for catalog
+        in (trace_offset_catalog, trace_length_catalog, cdp_catalog, line_catalog))
+
     if dimensionality == 1:
         return SegYReader(fh, textual_reel_header, binary_reel_header, extended_textual_header, trace_offset_catalog,
                           trace_length_catalog, trace_header_format, encoding, endian)

--- a/segpy/toolkit.py
+++ b/segpy/toolkit.py
@@ -732,7 +732,7 @@ def write_textual_reel_header(fh, lines, encoding):
                     for line in pad(lines, padding='', size=CARDS_PER_HEADER)]
     joined_header = EMPTY_BYTE_STRING.join(padded_lines)
     assert len(joined_header) == TEXTUAL_HEADER_NUM_BYTES
-    x = fh.write(joined_header)
+    fh.write(joined_header)
 
 
 def write_binary_reel_header(fh, binary_reel_header, endian='>'):

--- a/segpy/toolkit.py
+++ b/segpy/toolkit.py
@@ -732,7 +732,7 @@ def write_textual_reel_header(fh, lines, encoding):
                     for line in pad(lines, padding='', size=CARDS_PER_HEADER)]
     joined_header = EMPTY_BYTE_STRING.join(padded_lines)
     assert len(joined_header) == TEXTUAL_HEADER_NUM_BYTES
-    fh.write(joined_header)
+    x = fh.write(joined_header)
 
 
 def write_binary_reel_header(fh, binary_reel_header, endian='>'):
@@ -817,7 +817,6 @@ def write_extended_textual_headers(fh, pages, encoding):
         UnicodeError: If the textual data could not be encoded into the specified encoding.
 
     """
-
     if not is_supported_encoding(encoding):
         raise UnsupportedEncodingError("Writing extended textual header", encoding)
 

--- a/test/dataset_strategy.py
+++ b/test/dataset_strategy.py
@@ -202,9 +202,7 @@ def dataset(draw, dims):
                       min_size=dims,
                       max_size=dims))
     text_header = draw(textual_reel_header())
-    data_sample_format = draw(sampled_from(sorted(DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE)))
-    binary_header = draw(header(BinaryReelHeader,
-                                data_sample_format=data_sample_format))
+    binary_header = draw(header(BinaryReelHeader))
     ext_text_headers = draw(extended_textual_header(binary_header.num_extended_textual_headers))
 
     return InMemoryDataset(dims,

--- a/test/dataset_strategy.py
+++ b/test/dataset_strategy.py
@@ -1,0 +1,213 @@
+from hypothesis.strategies import composite, integers, lists, sampled_from, text, tuples
+from segpy.binary_reel_header import BinaryReelHeader
+from segpy.dataset import Dataset
+from segpy.datatypes import DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE
+from segpy.toolkit import CARD_LENGTH, CARDS_PER_HEADER
+from segpy.trace_header import TraceHeaderRev1
+
+from .strategies import header, PRINTABLE_ASCII_ALPHABET
+
+
+class InMemoryDataset(Dataset):
+    def __init__(self,
+                 dimensions,
+                 textual_reel_header,
+                 binary_reel_header,
+                 extended_textual_header,
+                 trace_header_type=TraceHeaderRev1):
+        """Args:
+            dimensions: An iterable of 1, 2, or 3 dimension extents.
+            trace_header_type: Constructor for new trace header instances.
+        """
+        self._dimensions = tuple(dimensions)
+        self._textual_reel_header = textual_reel_header
+        self._binary_reel_header = binary_reel_header
+        self._trace_header_type = trace_header_type
+
+        if binary_reel_header.num_extended_textual_headers >= 0:
+            assert binary_reel_header.num_extended_textual_headers == len(extended_textual_header)
+
+        self._extended_textual_header = extended_textual_header
+
+    @property
+    def textual_reel_header(self):
+        """The textual real header as an immutable sequence of forty Unicode strings each 80 characters long.
+        """
+        return self._textual_reel_header
+
+    @property
+    def binary_reel_header(self):
+        """The binary reel header.
+        """
+        return self._binary_reel_header
+
+    @property
+    def extended_textual_header(self):
+        return self._extended_textual_header
+
+    @property
+    def dimensionality(self):
+        """The spatial dimensionality of the data: 3 for 3D seismic volumes, 2 for 2D seismic lines, 1 for a
+        single trace_samples, otherwise 0.
+        """
+        return len(self._dimensions)
+
+    def trace_indexes(self):
+        """An iterator over zero-based trace_samples indexes.
+
+        Returns:
+            An iterator which yields integers in the range zero to
+            num_traces - 1
+        """
+        return range(self.num_traces())
+
+    def num_traces(self):
+        """The number of traces."""
+        return self._dimensions[0]
+
+    def trace_header(self, trace_index):
+        """The trace header for a given trace index.
+
+        Args:
+            trace_index: An integer in the range zero to num_traces() - 1
+
+        Returns:
+            A TraceHeader corresponding to the requested trace_samples.
+        """
+        # TODO: We should probably be using the header strategy to generate these instead.
+        return self._trace_header_type(
+            line_sequence_num=trace_index + 1,
+            file_sequence_num=trace_index + 1,
+            ensemble_trace_num=trace_index + 1)
+
+    def trace_samples(self, trace_index, start=None, stop=None):
+        """The trace samples for a given trace index.
+
+        Args:
+            trace_index: An integer in the range zero to num_traces - 1
+
+            start: Optional zero-based start sample index. The default
+                is to read from the first (i.e. zeroth) sample.
+
+            stop: Optional zero-based stop sample index. Following Python
+                slice convention this is one beyond the end.
+
+        Returns:
+            A sequence of numeric trace_samples samples.
+        """
+        start = 0 if start is None else start
+        stop = self.binary_reel_header.num_samples if stop is None else stop
+        return tuple(0 for _ in range(start, stop))
+
+
+@composite
+def textual_header_line(draw):
+    return draw(text(alphabet=PRINTABLE_ASCII_ALPHABET,
+                     min_size=CARD_LENGTH,
+                     max_size=CARD_LENGTH))
+
+
+@composite
+def textual_reel_header(draw):
+    return tuple(draw(lists(textual_header_line(),
+                            min_size=CARDS_PER_HEADER,
+                            max_size=CARDS_PER_HEADER)))
+
+
+END_TEXT_STANZA = tuple(
+    ['{:{width}}'.format('((SEG: EndText))', width=CARD_LENGTH)] + [' ' * CARD_LENGTH for _ in range(CARDS_PER_HEADER - 1)])
+
+
+@composite
+def stanza_header(draw):
+    "Generate an extended textual header stanza header."
+
+    alphabet = list(PRINTABLE_ASCII_ALPHABET)
+    # Remove the separator character
+    alphabet.remove(':')
+
+    org = draw(text(alphabet=alphabet,
+                    min_size=1,
+                    max_size=(CARD_LENGTH - 6) // 2))
+
+    name = draw(text(alphabet=alphabet,
+                     min_size=1,
+                     max_size=(CARD_LENGTH - 6) // 2))
+
+    header = '(({}: {}))'.format(org, name)
+    assert len(header) <= CARD_LENGTH
+
+    header = '{:{width}}'.format(header, width=CARD_LENGTH)
+    assert len(header) == CARD_LENGTH
+
+    return header
+
+
+@composite
+def stanza_line(draw):
+    "Generate an extended textual header stanze non-header line."
+
+    alphabet = list(PRINTABLE_ASCII_ALPHABET)
+    # Remove the separator character
+    alphabet.remove('=')
+
+    key = draw(text(alphabet=alphabet,
+                    min_size=1,
+                    max_size=(CARD_LENGTH - 3) // 2))
+
+    value = draw(text(alphabet=alphabet,
+                      min_size=1,
+                      max_size=(CARD_LENGTH - 3) // 2))
+
+    line = '{} = {}'.format(key, value)
+    assert len(line) <= CARD_LENGTH
+
+    line = '{:{width}}'.format(line, width=CARD_LENGTH)
+    assert len(line) == CARD_LENGTH
+
+    return line
+
+
+@composite
+def stanza(draw):
+    "Generate an extended textual header stanza."
+    count = draw(integers(min_value=0, max_value=CARDS_PER_HEADER - 1))
+    header = draw(stanza_header())
+    lines = [draw(stanza_line()) for _ in range(count)]
+    empty_lines = [' ' * CARD_LENGTH for _ in range(CARDS_PER_HEADER - 1 - count)]
+    full_stanza = [header] + lines + empty_lines
+    assert len(full_stanza) == CARDS_PER_HEADER
+    return tuple(full_stanza)
+
+
+@composite
+def extended_textual_header(draw, count):
+    if count == -1:
+        count = draw(integers(min_value=0, max_value=10))
+        headers = draw(lists(stanza(),
+                             min_size=count,
+                             max_size=count))
+        headers.append(END_TEXT_STANZA)
+        return headers
+
+    # TODO: This can *optionally* have an end-stanza. We should generate those sometimes.
+    return draw(lists(stanza(),
+                      min_size=count,
+                      max_size=count))
+
+
+@composite
+def dataset(draw, dims):
+    dims = draw(lists(integers(min_value=0, max_value=10),
+                      min_size=dims,
+                      max_size=dims))
+    text_header = draw(textual_reel_header())
+    data_sample_format = draw(sampled_from(sorted(DATA_SAMPLE_FORMAT_TO_SEG_Y_TYPE)))
+    binary_header = draw(header(BinaryReelHeader,
+                                data_sample_format=data_sample_format))
+    ext_text_headers = draw(extended_textual_header(binary_header.num_extended_textual_headers))
+
+    return InMemoryDataset(dims,
+                           text_header,
+                           binary_header,
+                           ext_text_headers)

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -78,7 +78,7 @@ class Test_create_reader_Exceptions:
     phases=(Phase.explicit, Phase.reuse, Phase.generate),
 )
 def test_round_trip(tmpdir, dataset):
-    segy_file = tmpdir / 'test.segy'
+    segy_file = str(tmpdir / 'test.segy')
 
     with open(segy_file, mode='bw') as fh:
         write_segy(fh, dataset)

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -3,17 +3,29 @@
 
 import io
 
-from hypothesis import assume, given
+from hypothesis import assume, given, HealthCheck, Phase, settings, unlimited
 import hypothesis.strategies as ST
 import pytest
+from segpy.header import are_equal
 from segpy.reader import create_reader
 from segpy.toolkit import REEL_HEADER_NUM_BYTES
+from segpy.writer import write_segy
+from .dataset_strategy import dataset
 
 
 @pytest.fixture
 def min_reader_data():
     "Binary data of minimal size to satisfy `create_reader`."
     return io.BytesIO(b'0' * REEL_HEADER_NUM_BYTES)
+
+
+# To test:
+# - cache directory
+# - progress callback
+# - round-tripping of data
+# - reader attributes
+# - 1, 2, and 3D data
+# - Dimensionality heuristics (i.e. passing `None` as dimensionality.)
 
 
 class Test_create_reader_Exceptions:
@@ -57,3 +69,27 @@ class Test_create_reader_Exceptions:
         with pytest.raises(ValueError):
             create_reader(min_reader_data,
                           dimensionality=dims)
+
+
+@given(dataset(dims=2))
+@settings(
+    suppress_health_check=(HealthCheck.too_slow,),
+    deadline=None,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate),
+)
+def test_round_trip(tmpdir, dataset):
+    segy_file = tmpdir / 'test.segy'
+
+    with open(segy_file, mode='bw') as fh:
+        write_segy(fh, dataset)
+
+    with open(segy_file, mode='br') as fh:
+        reader = create_reader(
+            fh,
+            trace_header_format=dataset._trace_header_type,
+            dimensionality=dataset.dimensionality)
+
+        assert dataset.textual_reel_header == reader.textual_reel_header
+        assert are_equal(dataset.binary_reel_header, reader.binary_reel_header)
+        assert dataset.extended_textual_header == reader.extended_textual_header
+        assert dataset.dimensionality == reader.dimensionality


### PR DESCRIPTION
This PR is primarily to get feedback on the approach. The main thing to look at is `dataset_strategy.py` which defines a hypothesis strategy for creating datasets. 

The checks I added in `reader.py` might only be necessary because of deficiencies in `InMemoryDataset`, and we might be able to remove them as the implementation improves.