### PR TITLE
Looking for AttributeErrors when cache pickling fails.

### DIFF
--- a/segpy/reader.py
+++ b/segpy/reader.py
@@ -192,7 +192,7 @@ def _save_reader_to_cache(reader, cache_file_path):
         with cache_file_path.open('wb') as cache_file:
             try:
                 pickle.dump(reader, cache_file)
-            except (pickle.PicklingError, TypeError) as pickling_error:
+            except (AttributeError, pickle.PicklingError, TypeError) as pickling_error:
                 log.warn("Could not pickle {} because {}".format(reader, pickling_error))
                 pass
     except OSError as os_error:


### PR DESCRIPTION
An `AttributeError` can happen when, for example, you try to pickle a lambda. I found this during some test development, and the associated tests will be part of a larger PR focused on tests for `reader.py`.