### PR TITLE
Moved IBM float un/packing routines out of toolkit.py into a new module.

### DIFF
--- a/segpy/ibm_float_packer.py
+++ b/segpy/ibm_float_packer.py
@@ -72,11 +72,6 @@ force_python_ibm_floats = False
 
 
 def _active_packer():
-    def foo(ext, data):
-        print('ext', ext, ext.obj)
-
-    _EXTENSION_MANAGER.map(foo, '')
-
     name = 'python'
     if 'cpp' in _EXTENSION_MANAGER and not force_python_ibm_floats:
         name = 'cpp'

--- a/segpy/ibm_float_packer.py
+++ b/segpy/ibm_float_packer.py
@@ -1,0 +1,68 @@
+"""Functions for packing and unpacking IBM floats to and from standard Python
+floats.
+
+The main job of this module is to select the correct implementation of the
+un/packing routines. The default version is written in pure Python, but if the
+faster C++ implementation is detected then it will be used.
+"""
+
+from segpy.ibm_float import IBMFloat
+from segpy.util import EMPTY_BYTE_STRING
+
+try:
+    import segpy_ibm_float_ext
+    _unpack_ibm_floats_cpp = segpy_ibm_float_ext.unpack_ibm_floats
+    _pack_ibm_floats_cpp = segpy_ibm_float_ext.pack_ibm_floats
+except ImportError:
+    _pack_ibm_floats_cpp = None
+    _unpack_ibm_floats_cpp = None
+
+
+# Boolean controller whether the Python implementation of IBM floating points
+# numbers will be required. If this is True, then the Python implementation
+# will always be used. If it is False (default) then the C++ implementation
+# will be used if it's available.
+#
+# This is primarily for testing purposes.
+force_python_ibm_floats = False
+
+
+def _unpack_ibm_floats_py(data, num_items):
+    return [IBMFloat.from_bytes(data[i: i+4])
+            for i in range(0, num_items * 4, 4)]
+
+
+def unpack_ibm_floats(data, num_items):
+    """Unpack a series of binary-encoded big-endian single-precision IBM floats.
+
+    Args:
+        data: A sequence of bytes.
+        num_items: The number of floats to be read.
+
+    Returns:
+        A sequence of floats.
+    """
+    if force_python_ibm_floats or not _unpack_ibm_floats_cpp:
+        return _unpack_ibm_floats_py(data, num_items)
+    else:
+        return _unpack_ibm_floats_cpp(data, num_items)
+
+
+def _pack_ibm_floats_py(values):
+    return EMPTY_BYTE_STRING.join(bytes(IBMFloat.from_real(value))
+                                  for value in values)
+
+
+def pack_ibm_floats(values):
+    """Pack floats into binary-encoded big-endian single-precision IBM floats.
+
+    Args:
+        values: An iterable series of numeric values.
+
+    Returns:
+        A sequence of bytes.
+    """
+    if force_python_ibm_floats or not _pack_ibm_floats_cpp:
+        return _pack_ibm_floats_py(values)
+    else:
+        return _pack_ibm_floats_cpp(values)

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['docopt_subcommands'],
+    install_requires=['docopt_subcommands', 'stevedore'],
 
     # List additional groups of dependencies here (e.g. development dependencies).
     # You can install these using the following syntax, for example:
@@ -114,5 +114,8 @@ setup(
         'console_scripts': [
             'segpy = segpy.cli:main',
         ],
+        'segpy.ibm_float_packer': [
+            'python = segpy.ibm_float_packer:Packer'
+        ]
     }
 )

--- a/test/test_ibm_float_packer.py
+++ b/test/test_ibm_float_packer.py
@@ -46,27 +46,27 @@ class TestPackImplementationSelection:
     @given(st.data())
     def test_python_pack_used_when_forced(self, data):
         data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.ibm_float_packer._pack_ibm_floats_py') as mock,\
+        with patch('segpy.ibm_float_packer.Packer.pack') as mock,\
              test.util.force_python_ibm_float(True):
             ibm_float_packer.pack_ibm_floats(data)
             assert mock.called
 
-    @pytest.mark.skipif(ibm_float_packer._pack_ibm_floats_cpp is None,
+    @pytest.mark.skipif('cpp' not in ibm_float_packer._EXTENSION_MANAGER,
                         reason="C++ IBM float not installed")
     @given(st.data())
     def test_cpp_pack_used_when_available(self, data):
         data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.ibm_float_packer._pack_ibm_floats_cpp') as mock,\
+        with patch('segpy_ibm_float_ext.Packer.pack') as mock,\
              test.util.force_python_ibm_float(False):
             ibm_float_packer.pack_ibm_floats(data)
             assert mock.called
 
-    @pytest.mark.skipif(ibm_float_packer._pack_ibm_floats_cpp is not None,
+    @pytest.mark.skipif('cpp' in ibm_float_packer._EXTENSION_MANAGER,
                         reason="C++ IBM float is installed")
     @given(st.data())
     def test_python_pack_used_as_fallback(self, data):
         data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.ibm_float_packer._pack_ibm_floats_py') as mock,\
+        with patch('segpy.ibm_float_packer.Packer.pack') as mock,\
              test.util.force_python_ibm_float(False):
             ibm_float_packer.pack_ibm_floats(data)
             assert mock.called
@@ -90,27 +90,27 @@ class TestUnpackImplementationSelection:
     @given(st.data())
     def test_python_unpack_used_when_forced(self, data):
         data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.ibm_float_packer._unpack_ibm_floats_py') as mock,\
+        with patch('segpy.ibm_float_packer.Packer.unpack') as mock,\
              test.util.force_python_ibm_float(True):
             ibm_float_packer.unpack_ibm_floats(*data)
             assert mock.called
 
-    @pytest.mark.skipif(ibm_float_packer._unpack_ibm_floats_cpp is None,
+    @pytest.mark.skipif('cpp' not in ibm_float_packer._EXTENSION_MANAGER,
                         reason="C++ IBM float not installed")
     @given(st.data())
     def test_cpp_unpack_used_when_available(self, data):
         data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.ibm_float_packer._unpack_ibm_floats_cpp') as mock,\
+        with patch('segpy_ibm_float_ext.Packer.unpack') as mock,\
              test.util.force_python_ibm_float(False):
             ibm_float_packer.unpack_ibm_floats(*data)
             assert mock.called
 
-    @pytest.mark.skipif(ibm_float_packer._unpack_ibm_floats_cpp is not None,
+    @pytest.mark.skipif('cpp' in ibm_float_packer._EXTENSION_MANAGER,
                         reason="C++ IBM float is installed")
     @given(st.data())
     def test_python_unpack_used_as_fallback(self, data):
         data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.ibm_float_packer._unpack_ibm_floats_py') as mock,\
+        with patch('segpy.ibm_float_packer.Packer.unpack') as mock,\
              test.util.force_python_ibm_float(False):
             ibm_float_packer.unpack_ibm_floats(*data)
             assert mock.called

--- a/test/test_ibm_float_packer.py
+++ b/test/test_ibm_float_packer.py
@@ -1,0 +1,116 @@
+from hypothesis import given
+import hypothesis.strategies as st
+import pytest
+from unittest.mock import patch
+
+from segpy import ibm_float_packer
+from segpy.ibm_float import EPSILON_IBM_FLOAT, ieee2ibm
+from segpy.util import almost_equal
+
+from test.test_float import ibm_compatible_floats
+import test.util
+
+
+@st.composite
+def byte_arrays_of_floats(draw):
+    num_items = draw(st.integers(min_value=0, max_value=10))
+    floats = draw(st.lists(ibm_compatible_floats(),
+                           min_size=num_items,
+                           max_size=num_items))
+    byte_data = b''.join([ieee2ibm(f) for f in floats])
+    return (byte_data, num_items)
+
+
+@pytest.mark.usefixtures("ibm_floating_point_impls")
+class TestPackIBMFloat:
+    def test_pack_empty(self):
+        dest = ibm_float_packer.pack_ibm_floats([])
+        assert len(dest) == 0
+
+    @given(st.lists(ibm_compatible_floats()))
+    def test_packed_floats_are_four_bytes(self, floats):
+        packed = ibm_float_packer.pack_ibm_floats(floats)
+        assert len(packed) == len(floats) * 4
+
+    @given(st.lists(ibm_compatible_floats()))
+    def test_roundtrip(self, data):
+        packed = ibm_float_packer.pack_ibm_floats(data)
+        unpacked = ibm_float_packer.unpack_ibm_floats(packed, len(data))
+        for f, u in zip(data, unpacked):
+            assert almost_equal(
+                f, float(u),
+                epsilon=EPSILON_IBM_FLOAT)
+
+
+class TestPackImplementationSelection:
+    @given(st.data())
+    def test_python_pack_used_when_forced(self, data):
+        data = data.draw(byte_arrays_of_floats())
+        with patch('segpy.ibm_float_packer._pack_ibm_floats_py') as mock,\
+             test.util.force_python_ibm_float(True):
+            ibm_float_packer.pack_ibm_floats(data)
+            assert mock.called
+
+    @pytest.mark.skipif(ibm_float_packer._pack_ibm_floats_cpp is None,
+                        reason="C++ IBM float not installed")
+    @given(st.data())
+    def test_cpp_pack_used_when_available(self, data):
+        data = data.draw(byte_arrays_of_floats())
+        with patch('segpy.ibm_float_packer._pack_ibm_floats_cpp') as mock,\
+             test.util.force_python_ibm_float(False):
+            ibm_float_packer.pack_ibm_floats(data)
+            assert mock.called
+
+    @pytest.mark.skipif(ibm_float_packer._pack_ibm_floats_cpp is not None,
+                        reason="C++ IBM float is installed")
+    @given(st.data())
+    def test_python_pack_used_as_fallback(self, data):
+        data = data.draw(byte_arrays_of_floats())
+        with patch('segpy.ibm_float_packer._pack_ibm_floats_py') as mock,\
+             test.util.force_python_ibm_float(False):
+            ibm_float_packer.pack_ibm_floats(data)
+            assert mock.called
+
+
+@pytest.mark.usefixtures("ibm_floating_point_impls")
+class TestUnpackIBMFloat:
+    def test_unpack_empty(self):
+        dest = ibm_float_packer.pack_ibm_floats(b'')
+        assert len(dest) == 0
+
+    @given(byte_arrays_of_floats())
+    def test_roundtrip(self, floats):
+        byte_data, num_items = floats
+        unpacked = ibm_float_packer.unpack_ibm_floats(byte_data, num_items)
+        packed = ibm_float_packer.pack_ibm_floats(unpacked)
+        assert bytes(byte_data) == bytes(packed)
+
+
+class TestUnpackImplementationSelection:
+    @given(st.data())
+    def test_python_unpack_used_when_forced(self, data):
+        data = data.draw(byte_arrays_of_floats())
+        with patch('segpy.ibm_float_packer._unpack_ibm_floats_py') as mock,\
+             test.util.force_python_ibm_float(True):
+            ibm_float_packer.unpack_ibm_floats(*data)
+            assert mock.called
+
+    @pytest.mark.skipif(ibm_float_packer._unpack_ibm_floats_cpp is None,
+                        reason="C++ IBM float not installed")
+    @given(st.data())
+    def test_cpp_unpack_used_when_available(self, data):
+        data = data.draw(byte_arrays_of_floats())
+        with patch('segpy.ibm_float_packer._unpack_ibm_floats_cpp') as mock,\
+             test.util.force_python_ibm_float(False):
+            ibm_float_packer.unpack_ibm_floats(*data)
+            assert mock.called
+
+    @pytest.mark.skipif(ibm_float_packer._unpack_ibm_floats_cpp is not None,
+                        reason="C++ IBM float is installed")
+    @given(st.data())
+    def test_python_unpack_used_as_fallback(self, data):
+        data = data.draw(byte_arrays_of_floats())
+        with patch('segpy.ibm_float_packer._unpack_ibm_floats_py') as mock,\
+             test.util.force_python_ibm_float(False):
+            ibm_float_packer.unpack_ibm_floats(*data)
+            assert mock.called

--- a/test/test_toolkit.py
+++ b/test/test_toolkit.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 import struct
 from hypothesis import given, settings, HealthCheck, Phase, assume
 import hypothesis.strategies as st
-import pytest
 from io import BytesIO
 from pytest import raises
 
@@ -13,123 +12,13 @@ from segpy.binary_reel_header import BinaryReelHeader
 from segpy.datatypes import DataSampleFormat, SegYType, SEG_Y_TYPE_TO_CTYPE, PY_TYPES, LIMITS
 from segpy.encoding import SUPPORTED_ENCODINGS, is_supported_encoding, UnsupportedEncodingError
 from segpy.header import are_equal
-from segpy.ibm_float import EPSILON_IBM_FLOAT, ieee2ibm
 import segpy.toolkit as toolkit
 from segpy.packer import make_header_packer
 from segpy.revisions import SegYRevision
 from segpy.trace_header import TraceHeaderRev1
-from segpy.util import almost_equal
-from unittest.mock import patch
 
 from test.dataset_strategy import extended_textual_header
 from test.strategies import header, NUMBER_STRATEGY, PRINTABLE_ASCII_ALPHABET
-import test.util
-from test.test_float import ibm_compatible_floats
-
-
-@st.composite
-def byte_arrays_of_floats(draw):
-    num_items = draw(st.integers(min_value=0, max_value=10))
-    floats = draw(st.lists(ibm_compatible_floats(),
-                           min_size=num_items,
-                           max_size=num_items))
-    byte_data = b''.join([ieee2ibm(f) for f in floats])
-    return (byte_data, num_items)
-
-
-@pytest.mark.usefixtures("ibm_floating_point_impls")
-class TestPackIBMFloat:
-    def test_pack_empty(self):
-        dest = toolkit.pack_ibm_floats([])
-        assert len(dest) == 0
-
-    @given(st.lists(ibm_compatible_floats()))
-    def test_packed_floats_are_four_bytes(self, floats):
-        packed = toolkit.pack_ibm_floats(floats)
-        assert len(packed) == len(floats) * 4
-
-    @given(st.lists(ibm_compatible_floats()))
-    def test_roundtrip(self, data):
-        packed = toolkit.pack_ibm_floats(data)
-        unpacked = toolkit.unpack_ibm_floats(packed, len(data))
-        for f, u in zip(data, unpacked):
-            assert almost_equal(
-                f, float(u),
-                epsilon=EPSILON_IBM_FLOAT)
-
-
-class TestPackImplementationSelection:
-    @given(st.data())
-    def test_python_pack_used_when_forced(self, data):
-        data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.toolkit.pack_ibm_floats_py') as mock,\
-             test.util.force_python_ibm_float(True):
-            toolkit.pack_ibm_floats(data)
-            assert mock.called
-
-    @pytest.mark.skipif(toolkit.pack_ibm_floats_cpp is None,
-                        reason="C++ IBM float not installed")
-    @given(st.data())
-    def test_cpp_pack_used_when_available(self, data):
-        data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.toolkit.pack_ibm_floats_cpp') as mock,\
-             test.util.force_python_ibm_float(False):
-            toolkit.pack_ibm_floats(data)
-            assert mock.called
-
-    @pytest.mark.skipif(toolkit.pack_ibm_floats_cpp is not None,
-                        reason="C++ IBM float is installed")
-    @given(st.data())
-    def test_python_pack_used_as_fallback(self, data):
-        data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.toolkit.pack_ibm_floats_py') as mock,\
-             test.util.force_python_ibm_float(False):
-            toolkit.pack_ibm_floats(data)
-            assert mock.called
-
-
-@pytest.mark.usefixtures("ibm_floating_point_impls")
-class TestUnpackIBMFloat:
-    def test_unpack_empty(self):
-        dest = toolkit.pack_ibm_floats(b'')
-        assert len(dest) == 0
-
-    @given(byte_arrays_of_floats())
-    def test_roundtrip(self, floats):
-        byte_data, num_items = floats
-        unpacked = toolkit.unpack_ibm_floats(byte_data, num_items)
-        packed = toolkit.pack_ibm_floats(unpacked)
-        assert bytes(byte_data) == bytes(packed)
-
-
-class TestUnpackImplementationSelection:
-    @given(st.data())
-    def test_python_unpack_used_when_forced(self, data):
-        data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.toolkit.unpack_ibm_floats_py') as mock,\
-             test.util.force_python_ibm_float(True):
-            toolkit.unpack_ibm_floats(*data)
-            assert mock.called
-
-    @pytest.mark.skipif(toolkit.unpack_ibm_floats_cpp is None,
-                        reason="C++ IBM float not installed")
-    @given(st.data())
-    def test_cpp_unpack_used_when_available(self, data):
-        data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.toolkit.unpack_ibm_floats_cpp') as mock,\
-             test.util.force_python_ibm_float(False):
-            toolkit.unpack_ibm_floats(*data)
-            assert mock.called
-
-    @pytest.mark.skipif(toolkit.unpack_ibm_floats_cpp is not None,
-                        reason="C++ IBM float is installed")
-    @given(st.data())
-    def test_python_unpack_used_as_fallback(self, data):
-        data = data.draw(byte_arrays_of_floats())
-        with patch('segpy.toolkit.unpack_ibm_floats_py') as mock,\
-             test.util.force_python_ibm_float(False):
-            toolkit.unpack_ibm_floats(*data)
-            assert mock.called
 
 
 class TestReadExtendedHeadersCounted:

--- a/test/util.py
+++ b/test/util.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-import segpy.toolkit as toolkit
+import segpy.ibm_float_packer
 
 
 @contextmanager
@@ -7,9 +7,9 @@ def force_python_ibm_float(force):
     """Configure segpy to run with and without the C++ implementation of IBM
     floating point un/packing.
     """
-    orig = toolkit.force_python_ibm_floats
-    toolkit.force_python_ibm_floats = force
+    orig = segpy.ibm_float_packer.force_python_ibm_floats
+    segpy.ibm_float_packer.force_python_ibm_floats = force
     try:
         yield force
     finally:
-        toolkit.force_python_ibm_floats = orig
+        segpy.ibm_float_packer.force_python_ibm_floats = orig


### PR DESCRIPTION
The main thing this does is pull all of the IBM float un/packing code out of `toolkit.py` into `ibm_float_packer.py`. This should make it easier to get `toolkit.py` coverage up to 100% by deconflating it with the techniques we use for detecting the C++ IBM float routines.

Full test coverage for the new module will still be tricky, though. As currently implemented, there will always be at least some part that can't be tested. This is because the C++ modules either can or cannot be imported; we can't have it both ways in a single test.

An alternative implementation using plugins (theme for the day!) might be able to get to 100% coverage if that's a goal we really want to achieve.