### PR TITLE
Using extension manager mocks to test un/packing implementation selection

### DIFF
--- a/segpy/ibm_float_packer.py
+++ b/segpy/ibm_float_packer.py
@@ -29,7 +29,7 @@ class PackerExtension(metaclass=abc.ABCMeta):
         Returns:
             A sequence of bytes.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def unpack(self, data, num_items):
@@ -42,7 +42,7 @@ class PackerExtension(metaclass=abc.ABCMeta):
         Returns:
             A sequence of floats.
         """
-        pass
+        raise NotImplementedError
 
 
 class Packer(PackerExtension):


### PR DESCRIPTION
These changes let us test the IBM float un/pack logic around implementation selection (i.e. Python or C++) without actually needing any particular implementation installed. We directly test the logic by using mocks. This means our tests are pretty closely bound to the implementation, but this seems like the cleanest way to get 100% statement coverage.