### PR TITLE
The Python IBM float packer is no longer provided as a plugin.

### DIFF
--- a/segpy/ibm_float_packer.py
+++ b/segpy/ibm_float_packer.py
@@ -72,11 +72,10 @@ force_python_ibm_floats = False
 
 
 def _active_packer():
-    name = 'python'
-    if 'cpp' in _EXTENSION_MANAGER and not force_python_ibm_floats:
-        name = 'cpp'
+    if force_python_ibm_floats or 'cpp' not in _EXTENSION_MANAGER:
+        return Packer()
 
-    return _EXTENSION_MANAGER[name].obj
+    return _EXTENSION_MANAGER['cpp'].obj
 
 
 def unpack_ibm_floats(data, num_items):

--- a/setup.py
+++ b/setup.py
@@ -113,9 +113,6 @@ setup(
     entry_points={
         'console_scripts': [
             'segpy = segpy.cli:main',
-        ],
-        'segpy.ibm_float_packer': [
-            'python = segpy.ibm_float_packer:Packer'
         ]
     }
 )

--- a/test/test_ibm_float_packer.py
+++ b/test/test_ibm_float_packer.py
@@ -66,18 +66,20 @@ class TestPackImplementationSelection:
     """This tests whether the correct pack implementation is selected.
     """
     @patch('segpy.ibm_float_packer._EXTENSION_MANAGER')
-    def test_python_pack_used_when_forced(self, mgr):
+    @patch('segpy.ibm_float_packer.Packer')
+    def test_python_pack_used_when_forced(self, python_packer, mgr):
         # Let the manager report that it contains 'cpp'
         mgr.__contains__ = MagicMock(return_value=True)
 
         data = byte_arrays_of_floats().example()
         with test.util.force_python_ibm_float(True):
             ibm_float_packer.pack_ibm_floats(data)
-            mgr.__getitem__.assert_called_once_with('python')
-            mgr.__getitem__.return_value.obj.pack.assert_called_with(data)
+            mgr.__getitem__.assert_not_called()
+            python_packer.return_value.pack.assert_called_with(data)
 
     @patch('segpy.ibm_float_packer._EXTENSION_MANAGER')
-    def test_cpp_pack_used_when_available(self, mgr):
+    @patch('segpy.ibm_float_packer.Packer')
+    def test_cpp_pack_used_when_available(self, python_packer, mgr):
         # Let the manager report that it contains 'cpp'
         mgr.__contains__ = MagicMock(return_value=True)
 
@@ -86,34 +88,37 @@ class TestPackImplementationSelection:
             ibm_float_packer.pack_ibm_floats(data)
             mgr.__getitem__.assert_called_once_with('cpp')
             mgr.__getitem__.return_value.obj.pack.assert_called_with(data)
+            python_packer.return_value.pack.assert_not_called()
 
 
     @patch('segpy.ibm_float_packer._EXTENSION_MANAGER')
-    def test_python_pack_used_as_fallback(self, mgr):
+    @patch('segpy.ibm_float_packer.Packer')
+    def test_python_pack_used_as_fallback(self, python_packer, mgr):
         # Don't let the manager report that it contains 'cpp'
         mgr.__contains__ = MagicMock(return_value=False)
 
         data = byte_arrays_of_floats()
         with test.util.force_python_ibm_float(False):
             ibm_float_packer.pack_ibm_floats(data)
-            mgr.__getitem__.assert_called_once_with('python')
-            mgr.__getitem__.return_value.obj.pack.assert_called_with(data)
+            python_packer.return_value.pack.assert_called_with(data)
 
 
 class TestUnpackImplementationSelection:
     @patch('segpy.ibm_float_packer._EXTENSION_MANAGER')
-    def test_python_unpack_used_when_forced(self, mgr):
+    @patch('segpy.ibm_float_packer.Packer')
+    def test_python_unpack_used_when_forced(self, python_packer, mgr):
         # Let the manager report that it contains 'cpp'
         mgr.__contains__ = MagicMock(return_value=True)
 
         data = byte_arrays_of_floats().example()
         with test.util.force_python_ibm_float(True):
             ibm_float_packer.unpack_ibm_floats(*data)
-            mgr.__getitem__.assert_called_once_with('python')
-            mgr.__getitem__.return_value.obj.unpack.assert_called_with(*data)
+            mgr.__getitem__.assert_not_called()
+            python_packer.return_value.unpack.assert_called_with(*data)
 
     @patch('segpy.ibm_float_packer._EXTENSION_MANAGER')
-    def test_cpp_unpack_used_when_available(self, mgr):
+    @patch('segpy.ibm_float_packer.Packer')
+    def test_cpp_unpack_used_when_available(self, python_packer, mgr):
         # Let the manager report that it contains 'cpp'
         mgr.__contains__ = MagicMock(return_value=True)
 
@@ -122,14 +127,16 @@ class TestUnpackImplementationSelection:
             ibm_float_packer.unpack_ibm_floats(*data)
             mgr.__getitem__.assert_called_once_with('cpp')
             mgr.__getitem__.return_value.obj.unpack.assert_called_with(*data)
+            python_packer.return_value.unpack.assert_not_called()
 
     @patch('segpy.ibm_float_packer._EXTENSION_MANAGER')
-    def test_python_unpack_used_as_fallback(self, mgr):
+    @patch('segpy.ibm_float_packer.Packer')
+    def test_python_unpack_used_as_fallback(self, python_packer, mgr):
         # Don't let the manager report that it contains 'cpp'
         mgr.__contains__ = MagicMock(return_value=False)
 
         data = byte_arrays_of_floats().example()
         with test.util.force_python_ibm_float(False):
             ibm_float_packer.unpack_ibm_floats(*data)
-            mgr.__getitem__.assert_called_once_with('python')
-            mgr.__getitem__.return_value.obj.unpack.assert_called_with(*data)
+            mgr.__getitem__.assert_not_called()
+            python_packer.return_value.unpack.assert_called_with(*data)


### PR DESCRIPTION
Instead, we only check if the C++ version is available as a plugin. If it's
not (or if Python is explicitly requested) then we simply return a Python packer
via normal means.

The main upshot is that you no longer need to install anything for tests to run.